### PR TITLE
Ensure that body is an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ exports.extend = function(app, options) {
 
         if (req.is('json')) {
             jsonBody(req, res, function(err, body) {
-                req.body = body;
+                req.body = body || {};
                 next();
             })
         } else {


### PR DESCRIPTION
Express guarantees that `req.body` is an object, but we have a case where the content-type is (incorrectly) json, but the body is empty, so this is setting `req.body` to be `undefined`. This is causing anything that checks `req.body.*` to throw.