### PR TITLE
Indicate whether a file was truncated

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,15 @@ exports.extend = function(app, options) {
                         file: out,
                         filename: filename,
                         encoding: encoding,
-                        mimetype: mimetype
+                        mimetype: mimetype,
+                        truncated: false
                     };
+
+                    // Indicate whether the file was truncated
+                    file.on('limit', function() {
+                        data.truncated = true;
+                    });
+
                     if (Array.isArray(req.files[name])) {
                         req.files[name].push(data);
                     } else if (req.files[name]) {


### PR DESCRIPTION
When you specify the `limits.fileSize` option busboy will stop reading the file. This PR indicates whether a file has been truncated.