### PR TITLE
Added arrayLimit option

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ exports.extend = function(app, options) {
             convertParams(req.body, name, data);
         });
         req.busboy.on('finish', () => {
-            req.body = qs.parse(qs.stringify(req.body));
+            req.body = qs.parse(qs.stringify(req.body), { arrayLimit: options.arrayLimit });
             if (restrictMultiple) {
                 [req.body, req.files].forEach(fixDups);
             }


### PR DESCRIPTION
When sending an array with more than 20 items `express-busboy` converts that array into an object, which of course it's not desired.

That limitation comes from `qs`:

> qs will also limit specifying indices in an array to a maximum index of 20. Any array members with an index of greater than 20 will instead be converted to an object with the index as the key This limit can be overridden by passing an arrayLimit option


```
{
	/* .. */
	'18': '18',
	'19': '19',
	'20': '20',
	'21': '21',	
}

```

Instead of

```
[
	/* .. */
	'18',
	'19',
	'20',
	'21'
]
```

Added an `arrayLimit` option, that will be passed onto `qs.parse`

```
bb.extend(app, {
    arrayLimit: 50
});
```
