### PR TITLE
Sanitize the name and filename params, make major version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ options.mimeTypeLimit = [
 ];
 ```
 
+Name and filename inputs will be sanitized before determining path for the file on disk.  If you want to change this behavior you can provide a strip function of your own:
+
+```js
+// this will not sanitize the inputs
+options.strip = function(value, type) {
+    return value;
+}
+```
+
 When files are not uploaded due to path or mimetype checks, no error is returned (so the other data in the request can be handled) the restricted item
 will simply not appear in the `req.files` `Object`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-busboy",
   "description": "Busboy for express, mimics the old bodyParser",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "author": "Dav Glass <davglass@gmail.com>",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated to sanitize inputs for creating the "out" path on disk.  The original name and filename are not changed, just the location for writing to.

Updated docs to reflect the new override function that you can use to revert to previous behavior, or change the path stripping in a way that is more appropriate for individual use cases.

Updated test to confirm the path is being stipped, and that the custom function can be provided.

Bumped to major version 8.0.0 as this is a breaking change.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
