### PR TITLE
fix: use md5 hash for filename to avoid path traversal vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bb.extend(app, {
 ```
 
 By default this module will create an `Array` when it finds multiple fields with the
-same name in the POST parameters. You can set `restrictMultiple` to `true` to 
+same name in the POST parameters. You can set `restrictMultiple` to `true` to
 not parse mutiple POST values into `Array`'s
 
 file uploads
@@ -46,8 +46,7 @@ bb.extend(app, {
 
 `path` will default to: `os.tmpdir()/express-busboy/<uuid>/<the field name>/<filename>`.
 
-allowedPath can contain a regular expression limiting the upload function to given urls. For example `/^\/upload$/` would only allow uploads in the /upload path.
-
+`allowedPath` can contain a regular expression limiting the upload function to given urls. For example `/^\/upload$/` would only allow uploads in the /upload path.
 
 You can have a function returning true/false if you prefer that:
 
@@ -68,7 +67,7 @@ options.mimeTypeLimit = [
 ];
 ```
 
-Name and filename inputs will be sanitized before determining path for the file on disk.  If you want to change this behavior you can provide a strip function of your own:
+Name and filename inputs will be sanitized into an MD5 hash before determining path for the file on disk.  If you want to change this behavior you can provide a strip function of your own:
 
 ```js
 // this will not sanitize the inputs
@@ -77,5 +76,4 @@ options.strip = function(value, type) {
 }
 ```
 
-When files are not uploaded due to path or mimetype checks, no error is returned (so the other data in the request can be handled) the restricted item
-will simply not appear in the `req.files` `Object`.
+When files are not uploaded due to path or mimetype checks, no error is returned (so the other data in the request can be handled) the restricted item will simply not appear in the `req.files` `Object`.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const mkdirp = require('mkdirp');
 const qs = require('qs');
 const os = require('os');
 const jsonBody = require('body/json');
+const crypto = require('crypto');
 
 const fixDups = (item) => {
     Object.keys(item).forEach((field) => {
@@ -25,9 +26,12 @@ const fixDups = (item) => {
     return item;
 };
 
-const stripRegexp = /.*\//;
+const md5 = (value) => {
+    return crypto.createHash('md5').update(value).digest("hex");
+};
+
 const strip = (value) => {
-    return value.replace(stripRegexp, '');
+    return md5(value);
 };
 
 var convertParams = (item, name, data) => {


### PR DESCRIPTION
Fixes https://hackerone.com/reports/1908318

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
